### PR TITLE
Fix ring buffer overflow corruption and add regression test

### DIFF
--- a/cpp/ring-buffer/ring_buffer.cpp
+++ b/cpp/ring-buffer/ring_buffer.cpp
@@ -3,7 +3,7 @@
 
 RingBuffer::RingBuffer(size_t capacity, size_t inRate, size_t outRate, size_t inBlockSize, size_t outBlockSize, size_t outputOverlap)
     : capacity(capacity), inRate(inRate), outRate(outRate), inBlockSize(inBlockSize), 
-        outBlockSize(outBlockSize), outputOverlap(outputOverlap), inIndex(0), outIndex(0) {
+        outBlockSize(outBlockSize), outputOverlap(outputOverlap), inIndex(0), outIndex(0), size(0) {
     buffer.resize(capacity, 0.0f);
 }
 
@@ -16,16 +16,17 @@ bool RingBuffer::write(const std::vector<float>& data) {
         return false;
     }
 
+    if (inBlockSize > (capacity - size)) {
+        std::cerr << "Buffer overflow." << std::endl;
+        return false;
+    }
+
     for (size_t i = 0; i < inBlockSize; ++i) {
         buffer[inIndex] = data[i];
         inIndex = (inIndex + 1) % capacity;
-        
-        if (inIndex == outIndex) {
-            std::cerr << "Buffer overflow." << std::endl;
-            return false;
-        }
     }
 
+    size += inBlockSize;
     return true;
 }
 
@@ -33,10 +34,9 @@ bool RingBuffer::read(std::vector<float>& data) {
     std::lock_guard<std::mutex> lock(mutex);
     data.clear();
 
-    size_t availableSamples = (inIndex + capacity - outIndex) % capacity;
     size_t expectedSamples = outBlockSize + outputOverlap;
 
-    if (availableSamples < expectedSamples) {
+    if (size < expectedSamples) {
         std::cerr << "Not enough data available." << std::endl;
         return false;
     }
@@ -46,9 +46,13 @@ bool RingBuffer::read(std::vector<float>& data) {
         outIndex = (outIndex + 1) % capacity;
     }
 
+    size -= expectedSamples;
+
     // Adjust for output rate
     outIndex = (outIndex + capacity - (outBlockSize * outRate / inRate)) % capacity;
-    
+    size_t rewind = outBlockSize * outRate / inRate;
+    size += rewind;
+
     return true;
 }
 

--- a/cpp/ring-buffer/ring_buffer.h
+++ b/cpp/ring-buffer/ring_buffer.h
@@ -20,6 +20,7 @@ private:
     size_t outBlockSize;
     size_t capacity;
     size_t outputOverlap;
+    size_t size;
     std::mutex mutex;
 };
 

--- a/cpp/ring-buffer/test_ring_buffer.cpp
+++ b/cpp/ring-buffer/test_ring_buffer.cpp
@@ -10,6 +10,39 @@ std::vector<float> generateRamp(size_t start, size_t size) {
     return ramp;
 }
 
+
+
+bool testOverflowKeepsDataIntact() {
+    RingBuffer ringBuffer(10, 1, 1, 6, 4, 0);
+
+    std::vector<float> first = {0, 1, 2, 3, 4, 5};
+    std::vector<float> second = {10, 11, 12, 13, 14, 15};
+
+    if (!ringBuffer.write(first)) {
+        std::cerr << "Initial write failed." << std::endl;
+        return false;
+    }
+
+    if (ringBuffer.write(second)) {
+        std::cerr << "Expected overflow write to fail." << std::endl;
+        return false;
+    }
+
+    std::vector<float> outputData;
+    if (!ringBuffer.read(outputData)) {
+        std::cerr << "Read failed after overflow." << std::endl;
+        return false;
+    }
+
+    std::vector<float> expected = {0, 1, 2, 3};
+    if (outputData != expected) {
+        std::cerr << "Unexpected read data after overflow." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
 int main() {
     // Parameters for the ring buffer
     size_t capacity = 100;          // Total capacity of the ring buffer
@@ -58,6 +91,10 @@ int main() {
             std::cout << outputData[i] << " ";
         }
         std::cout << std::endl;
+    }
+
+    if (!testOverflowKeepsDataIntact()) {
+        return -1;
     }
 
     return 0;


### PR DESCRIPTION
### Motivation
- Prevent data corruption when a write would overflow the ring buffer by avoiding partial mutation of internal indices before verifying capacity.  
- Make buffer availability checks robust by tracking the current buffered sample count explicitly.  
- Add regression coverage to ensure failed overflow writes do not alter previously buffered data.

### Description
- Add a `size` member to `RingBuffer` and initialize it in the constructor to track the number of buffered samples.  
- Update `RingBuffer::write` to check `inBlockSize > (capacity - size)` and return before mutating `inIndex` or buffer contents when an overflow would occur.  
- Update `RingBuffer::read` to validate availability using `size`, subtract `expectedSamples` after reading, and adjust `size` for the overlap/rewind calculation to keep accounting consistent.  
- Add `testOverflowKeepsDataIntact()` to `cpp/ring-buffer/test_ring_buffer.cpp` which verifies that a failed overflow write returns `false` and that previously written data can still be read correctly.

### Testing
- Compiled and ran the test harness with `g++ -std=c++17 cpp/ring-buffer/ring_buffer.cpp cpp/ring-buffer/test_ring_buffer.cpp -o /tmp/test_rb && /tmp/test_rb`, which completed successfully.  
- Built and ran a minimal repro with `g++ -std=c++17 -I. cpp/ring-buffer/ring_buffer.cpp /tmp/repro.cpp -o /tmp/repro && /tmp/repro`, which confirmed the overflow write fails and subsequent read returns the expected data.  
- The added regression test `testOverflowKeepsDataIntact` was executed as part of the test binary and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69999d65ee04832bad43552232b85d33)